### PR TITLE
Fixed the FMKC discord link

### DIFF
--- a/wiki/landing-page.md
+++ b/wiki/landing-page.md
@@ -18,7 +18,7 @@ Every contribution is deeply appreciated.
 
 
 ### Discord
-You can join our discord through this link > [discord.fmkc.fi](discord.fmkc.fi)
+You can join our discord through this link > [discord.fmkc.fi](https://www.discord.fmkc.fi)
 
 ## Code of Conduct
 

--- a/wiki/landing-page.md
+++ b/wiki/landing-page.md
@@ -18,7 +18,7 @@ Every contribution is deeply appreciated.
 
 
 ### Discord
-You can join our discord through this link > [discord.fmkc.fi](https://www.discord.fmkc.fi)
+You can join our discord through this link > [discord.fmkc.fi](https://discord.fmkc.fi)
 
 ## Code of Conduct
 


### PR DESCRIPTION
The link (without HTTPS) links to `https://blog.kristiansyrjanen.com/wiki/discord.fmkc.fi`.
Fixed it so that it links to `https://www.discord.fmkc.fi/`